### PR TITLE
Introduce electron-packager and fix README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+*-darwin-x64/

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ git clone --recursive https://github.com/prg-titech/Kanon.git
 This will copy the source code of Kanon as well as the external libraries.
 After downloaded, go to the Kanon directory and open [index.html](https://github.com/prg-titech/Kanon/blob/master/index.html).
 
-Also you can build __Kanon__ with `nvm`.
+Also you can build __Kanon__ with `npm`.
 
 ```
-nvm install
-nvm start
+npm install
+npm start
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ git clone --recursive https://github.com/prg-titech/Kanon.git
 This will copy the source code of Kanon as well as the external libraries.
 After downloaded, go to the Kanon directory and open [index.html](https://github.com/prg-titech/Kanon/blob/master/index.html).
 
-## 
+Also you can build __Kanon__ with `nvm`.
+
+```
+nvm install
+nvm start
+```
+
+---
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A live programming environment specialized for data structure programming.",
   "main": "app.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "create": "node_modules/.bin/electron-packager . --platform=darwin --overwrite",
+    "open": "open Kanon-darwin-x64/Kanon.app"
   },
   "repository": {
     "type": "git",
@@ -17,9 +19,10 @@
   },
   "homepage": "https://github.com/prg-titech/Kanon#readme",
   "dependencies": {
+    "ace-builds": "^1.2.5",
     "electron": "^1.6.7",
+    "electron-packager": "^8.7.0",
     "esprima": "^3.1.3",
-    "vis": "4.17.0",
-    "ace-builds": "^1.2.5"
+    "vis": "4.17.0"
   }
 }


### PR DESCRIPTION
## Purpose

This introduces `electron-packager`, creating stand-alone app, and includes some fix of `README.md` explaining how to build with `nvm`.

## Usage

You can create and start stand alone app by executing the command below.

```bash
npm run-script create
npm run-script open
```
