### PR TITLE
record timestamp in snapshots

### DIFF
--- a/src/js/code-instrumentation/checkpoint.js
+++ b/src/js/code-instrumentation/checkpoint.js
@@ -104,7 +104,7 @@ __$__.Checkpoint = {
 
     StoreGraph: function(objects, loopLabel, timeCounter, checkPointId, probe, contextSensitiveID) {
         let graph = (__$__.Context.ChangedGraph)
-            ? __$__.Traverse.traverse(objects, probe)
+            ? __$__.Traverse.traverse(objects, probe, timeCounter)
             : __$__.Context.LastGraph;
 
 

--- a/src/js/object2graph/graph.js
+++ b/src/js/object2graph/graph.js
@@ -193,7 +193,7 @@ __$__.StoredGraphFormat = {
 
 
     Graph: class __Graph__ {
-        constructor() {
+        constructor(timeCounter) {
             this.nodes = {};
             this.edges = [];
             this.variableNodes = {};
@@ -202,6 +202,7 @@ __$__.StoredGraphFormat = {
             this.CustomMode = false;
             this.FisheyeView = true;
             this.notInterestedClass = [];
+	    this.timeCounter = timeCounter;
         }
 
         pushNode(node) {

--- a/src/js/object2graph/traverse.js
+++ b/src/js/object2graph/traverse.js
@@ -7,8 +7,8 @@ __$__.Traverse = {
     },
     
     
-    traverse: function(objs, variables = {}) {
-        let retGraph = new __$__.StoredGraphFormat.Graph();
+    traverse: function(objs, variables = {}, timeCounter) {
+        let retGraph = new __$__.StoredGraphFormat.Graph(timeCounter);
         let graphNodes = {};
 
         for (let i = 0; i < objs.length; i++) {


### PR DESCRIPTION
With this change, snapshots recorded in __$__.Context.StoredGraph have the time of creation in timeCounter field.  Below is an example:

__$__.Context.StoredGraph[1]["main-call3-FunctionExpression3-new1-FunctionExpression1"] = Object { nodes: {…}, edges: [], variableNodes: {…}, variableEdges: (1) […],
           makeChanges: false, CustomMode: false, FisheyeView: true,
           notInterestedClass: [],
           timeCounter: 14 } // <--- watch this

This should be useful for making animation, where we want to collect snapshots without walking down a call tree and sort by the time.